### PR TITLE
fix for the errors in the file fib.ts 

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n:number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
added 'number' return type to omit the error 'Unsafe return of an `any` typed value'. Changes have been tested using the lint & tested by using the command npm run lint, this pr is the fix for issue #1 